### PR TITLE
Add return types to comply with noImplicitAny rule

### DIFF
--- a/Node/src/TeamsChatConnector.ts
+++ b/Node/src/TeamsChatConnector.ts
@@ -113,7 +113,7 @@ export class TeamsChatConnector extends builder.ChatConnector {
   *  Set the list of allowed tenants. Messages from tenants not on the list will be dropped silently.
   *  @param {array} tenants - Ids of allowed tenants.
   */
-  public setAllowedTenants(tenants: string[]) {
+  public setAllowedTenants(tenants: string[]) : void {
     if (tenants != null) {
       this.allowedTenants = tenants;
     }
@@ -122,7 +122,7 @@ export class TeamsChatConnector extends builder.ChatConnector {
   /**
   *  Reset allowed tenants, ask connector to receive every message sent from any source.
   */
-  public resetAllowedTenants() {
+  public resetAllowedTenants() : void {
     this.allowedTenants = null;
   }
 

--- a/Node/src/botbuilder-teams.d.ts
+++ b/Node/src/botbuilder-teams.d.ts
@@ -499,12 +499,12 @@ export class TeamsChatConnector extends builder.ChatConnector {
   *  Set the list of allowed tenants. Messages from tenants not on the list will be dropped silently.
   *  @param {array} tenants - Ids of allowed tenants.
   */
-  public setAllowedTenants(tenants: string[]);
+  public setAllowedTenants(tenants: string[]) : void;
 
   /**
   *  Reset allowed tenants, ask connector to receive every message sent from any source.
   */
-  public resetAllowedTenants();
+  public resetAllowedTenants() : void;
 
   public onQuery(commandId: string, handler: ComposeExtensionQueryHandlerType): void;
 }


### PR DESCRIPTION
When using this library, tsc (with the noImplicitAny rule enabled) gives errors due to these functions not having a return type.  This commit adds the return type `void` to the functions and their declarations in the .d.ts file.

Thanks!