### PR TITLE
Export MentionTextLocation enum

### DIFF
--- a/Node/src/botbuilder-teams.ts
+++ b/Node/src/botbuilder-teams.ts
@@ -33,6 +33,7 @@
 
 export { TeamsChatConnector } from './TeamsChatConnector';
 export { TeamsMessage } from './TeamsMessage';
+export { MentionTextLocation } from './TeamsMessage';
 export { ChannelInfo } from './models';
 export { ConversationList } from './models';
 export { TeamInfo } from './models';


### PR DESCRIPTION
This enum needs to be exported in order to be used. It's in the d.ts file but is never exported. 

Your tests miss this because it imports TeamsMessage directly.

I found this when trying to use the SDK but was tearing my hair out because I kept getting compilation errors. It never occurred to me until this morning that the problem was that it was never exported from botbuilder-teams.ts / .js.