### PR TITLE
1) add invoke handler for signin state verification. 2) add full example of FB auth using signin card - Node.js

### DIFF
--- a/Node/package.json
+++ b/Node/package.json
@@ -11,6 +11,7 @@
   "typings": "./lib/botbuilder-teams.d.ts",
   "dependencies": {
     "botbuilder": "^3.9.0",
+    "crypto": "^1.0.1",
     "ms-rest": "^1.15.7",
     "sprintf-js": "^1.1.1"
   },

--- a/Node/samples/app.ts
+++ b/Node/samples/app.ts
@@ -14,6 +14,7 @@ import * as restify from 'restify';
 import * as builder from 'botbuilder';
 import * as https from 'https';
 import * as teams from 'botbuilder-teams';
+import { SimpleFBAuth, IFacebookAppSigninSettings } from './simpleFBAuth';
 
 // Put your registered bot here, to register bot, go to bot framework
 var appName: string = 'app name';
@@ -41,6 +42,15 @@ connector.resetAllowedTenants();
 server.post('/api/v1/bot/messages', connector.listen());
 var bot = new builder.UniversalBot(connector);
 
+// create the bot auth agent
+let botSigninSettings: IFacebookAppSigninSettings = {
+  baseUrl: 'https://...',                         // put the base url of current service
+  fbAppClientId: 'fb app id',                     // put Facebook app id
+  fbAppClientSecret: 'fb app secret',             // put Facebook app secret
+  fbAppScope: 'public_profile,email,user_friends' // put Facebook access scope
+};
+var botAuth = SimpleFBAuth.create(server, connector, botSigninSettings);
+
 // Strip bot at mention text, set text property to text without specific Bot at mention, find original text in textWithBotMentions
 // e.g. original text "<at>zel-bot-1</at> hello please find <at>Bot</at>" and zel-bot-1 is the Bot we at mentions. 
 // Then it text would be "hello please find <at>Bot</at>", the original text could be found at textWithBotMentions property.
@@ -50,7 +60,7 @@ bot.use(stripBotAtMentions);
 
 bot.dialog('/', [
   function (session) {
-    builder.Prompts.choice(session, "Choose an option:", 'Fetch channel list|Mention user|Start new 1 on 1 chat|Route message to general channel|FetchMemberList|Send O365 actionable connector card|FetchTeamInfo(at Bot in team)|Start New Reply Chain (in channel)');
+    builder.Prompts.choice(session, "Choose an option:", 'Fetch channel list|Mention user|Start new 1 on 1 chat|Route message to general channel|FetchMemberList|Send O365 actionable connector card|FetchTeamInfo(at Bot in team)|Start New Reply Chain (in channel)|Issue a Signin card to sign in a Facebook app|Logout Facebook app and clear cached credentials');
   },
   function (session, results) {
     switch (results.response.index) {
@@ -77,6 +87,12 @@ bot.dialog('/', [
         break;
       case 7:
         session.beginDialog('StartNewReplyChain');
+        break;
+      case 8:
+        session.beginDialog('Signin');
+        break;
+      case 9:
+        session.beginDialog('Signout');
         break;
       default:
         session.endDialog();
@@ -390,6 +406,14 @@ var o365CardActionHandler = function (event: builder.IEvent, query: teams.IO365C
 }
 
 connector.onO365ConnectorCardAction(o365CardActionHandler);
+
+// example for signin card
+
+bot.dialog('Signin', (session: builder.Session) => botAuth.botSignIn(session));
+
+bot.dialog('Signout', (session: builder.Session) => botAuth.botSignOut(session));
+
+connector.onSigninStateVerification((event: builder.IEvent, query: teams.ISigninStateVerificationQuery, callback: (err: Error, result: any, statusCode?: number) => void) => botAuth.verifySigninState(event, query, callback));
 
 // example for compose extension
 var composeExtensionHandler = function (event: builder.IEvent, query: teams.ComposeExtensionQuery, callback: (err: Error, result: teams.IComposeExtensionResponse, statusCode: number) => void): void {

--- a/Node/samples/simpleFBAuth.js
+++ b/Node/samples/simpleFBAuth.js
@@ -1,0 +1,222 @@
+"use strict";
+exports.__esModule = true;
+var builder = require("botbuilder");
+var restify = require("restify");
+var crypto = require("crypto");
+var request = require("request");
+var SimpleFBAuth = /** @class */ (function () {
+    function SimpleFBAuth(server) {
+        var _this = this;
+        this.userIdFacebookTokenCache = {};
+        server.use(restify.queryParser());
+        server.get(SimpleFBAuth.AuthStartPath + '/:userId', function (req, res, next) { return _this.authStart(req, res, next); });
+        server.get(SimpleFBAuth.AuthCallbackPath, function (req, res, next) { return _this.authCallback(req, res, next); });
+        server.get(SimpleFBAuth.AuthStartOAuthPath, function (req, res, next) { return _this.authStartOAuth(req, res, next); });
+    }
+    SimpleFBAuth.create = function (server, connector, settings) {
+        if (!SimpleFBAuth.instance) {
+            SimpleFBAuth.instance = new SimpleFBAuth(server);
+        }
+        SimpleFBAuth.instance.connector = connector;
+        SimpleFBAuth.instance.settings = settings;
+        return SimpleFBAuth.instance;
+    };
+    SimpleFBAuth.prototype.botSignIn = function (session) {
+        var _this = this;
+        var userId = session.message.address.user.id;
+        var issueNewCard = function () {
+            var authUrl = _this.settings.baseUrl + SimpleFBAuth.AuthStartPath + '/' + userId;
+            var card = new builder.SigninCard(session).text('Sign in Facebook app').button('Login', authUrl);
+            var msg = new builder.Message(session).attachments([card]);
+            session.send(msg);
+            session.endDialog();
+        };
+        if (this.userIdFacebookTokenCache[userId]) {
+            // Use cached token
+            var token = this.userIdFacebookTokenCache[userId];
+            // Send a thumbnail card with user's FB profile
+            this.CreateFBProfileCard(token, function (card) {
+                if (card) {
+                    var msg = new builder.Message(session)
+                        .text('Cached credential is found. Use cached token to fetch info.')
+                        .attachments([card]);
+                    session.send(msg);
+                    session.endDialog();
+                }
+                else {
+                    // Token is invalid to fetch info (i.e., expired)
+                    issueNewCard();
+                }
+            });
+        }
+        else {
+            // No token cached: issue a new Signin card
+            issueNewCard();
+        }
+    };
+    SimpleFBAuth.prototype.botSignOut = function (session) {
+        var userId = session.message.address.user.id;
+        delete this.userIdFacebookTokenCache[userId];
+        var msg = new builder.Message(session).text('Your cached credential has been removed.');
+        session.send(msg);
+        session.endDialog();
+    };
+    SimpleFBAuth.prototype.verifySigninState = function (event, query, callback) {
+        var _this = this;
+        var sendMessage = function (text, card) {
+            var msg = new builder.Message().address(event.address);
+            if (text) {
+                msg.text(text);
+            }
+            if (card) {
+                msg.attachments([card]);
+            }
+            _this.connector.send([msg.toMessage()], null);
+        };
+        // Decrypt state string to get code and original userId & channelId
+        var state = this.decryptState(query.state);
+        var trustableUserId = event.address.user.id;
+        var trustableChannelId = event.sourceEvent.channel && event.sourceEvent.channel.id;
+        var invalidUserId = state.userId !== trustableUserId;
+        var invalidChannelId = state.channelId && trustableChannelId && state.channelId !== trustableChannelId;
+        // Verify userId & channelId
+        if (invalidUserId || invalidChannelId) {
+            sendMessage('Unauthorized: User ID verification failed. Please try again.');
+            callback(new Error('User ID verification failed'), null, 401);
+            return;
+        }
+        else {
+            // Prepare FB OAuth request
+            var fbAppId = this.settings.fbAppClientId;
+            var fbOAuthRedirectUrl = this.settings.baseUrl + SimpleFBAuth.AuthCallbackPath;
+            var fbAppSecret = this.settings.fbAppClientSecret;
+            var fbOAuthTokenUrl = 'https://graph.facebook.com/v2.10/oauth/access_token';
+            var fbOAuthTokenParams = "?client_id=" + fbAppId + "&redirect_uri=" + fbOAuthRedirectUrl + "&client_secret=" + fbAppSecret + "&code=" + state.accessCode;
+            // Use access code to exchange FB token
+            request.get(fbOAuthTokenUrl + fbOAuthTokenParams, function (error, response, body) {
+                if (!error && response.statusCode == 200) {
+                    var tokenObj = JSON.parse(body);
+                    // Update cache
+                    var fbToken = tokenObj['access_token'];
+                    _this.userIdFacebookTokenCache[trustableUserId] = fbToken;
+                    // Send a thumbnail card with user's FB profile
+                    _this.CreateFBProfileCard(fbToken, function (card) {
+                        if (card) {
+                            sendMessage(null, card);
+                            callback(null, null, 200);
+                            return;
+                        }
+                        else {
+                            sendMessage('Could not fetch your facebook info. Please try again later.');
+                            callback(new Error('Facebook API call failed'), null, 500);
+                            return;
+                        }
+                    });
+                }
+                else {
+                    sendMessage('Facebook token update failed. Please try again later.');
+                    callback(new Error('Facebook token update failed'), null, 500);
+                    return;
+                }
+            });
+        }
+    };
+    SimpleFBAuth.prototype.authStart = function (req, res, next) {
+        var userId = req.params.userId;
+        var authUrl = this.settings.baseUrl + SimpleFBAuth.AuthStartOAuthPath;
+        var body = "\n      <html>\n        <head>\n          <script src='" + SimpleFBAuth.TeamsSDK + "'></script>\n        </head>\n        <body>\n          <script>\n            microsoftTeams.initialize();\n            microsoftTeams.getContext((context) => {\n              //- Save user and channel id to cookie\n              document.cookie = 'userId=' + '" + userId + "' + '; Path=/';\n              if (context.channelId) {\n                document.cookie = 'channelId=' + context.channelId + ';Path=/';\n              } else {\n                document.cookie = 'channelId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';\n              }\n              window.location = '" + authUrl + "';\n            });        \n          </script>\n        </body>\n      </html>\n    ";
+        res.writeHead(200, {
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Type': 'text/html'
+        });
+        res.write(body);
+        res.end();
+    };
+    SimpleFBAuth.prototype.authStartOAuth = function (req, res, next) {
+        var fbAppId = this.settings.fbAppClientId;
+        var fbOAuthRedirectUrl = this.settings.baseUrl + SimpleFBAuth.AuthCallbackPath;
+        var fbAppScope = this.settings.fbAppScope;
+        var fbOAuthUrl = "https://www.facebook.com/v2.10/dialog/oauth?client_id=" + fbAppId + "&redirect_uri=" + fbOAuthRedirectUrl + "&scope=" + fbAppScope;
+        res.redirect(fbOAuthUrl, next);
+    };
+    SimpleFBAuth.prototype.authCallback = function (req, res, next) {
+        var onAuthResultBody = function (succeeded, state) {
+            return succeeded ? "\n      <html>\n        <head>\n          <script src='" + SimpleFBAuth.TeamsSDK + "'></script>        \n        </head>\n        <body>\n          <script>\n            microsoftTeams.initialize();\n            microsoftTeams.authentication.notifySuccess('" + state + "');\n          </script>\n        </body>\n      </html>\n      " : "\n      <html>\n        <head>\n          <script src='" + SimpleFBAuth.TeamsSDK + "'></script>\n        </head>\n        <body>\n          <script>\n            microsoftTeams.initialize();\n            microsoftTeams.authentication.notifyFailure();\n          </script>\n        </body>\n      </html>\n    ";
+        };
+        var body = '';
+        if (req.query.code) {
+            var cookie = this.parseCookie(req.headers.cookie);
+            var state = {
+                userId: cookie.userId,
+                accessCode: req.query.code,
+                channelId: cookie.channelId
+            };
+            body = onAuthResultBody(true, this.encryptState(state));
+        }
+        else {
+            body = onAuthResultBody(false);
+        }
+        res.writeHead(200, {
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Type': 'text/html'
+        });
+        res.write(body);
+        res.end();
+    };
+    SimpleFBAuth.prototype.CreateFBProfileCard = function (fbToken, callback) {
+        // Use FB token to perform graph API to fetch user FB information
+        var fbGraphUrl = function (endPoint, params) { return 'https://graph.facebook.com/' + endPoint + ("?access_token=" + fbToken + "&") + params; };
+        request.get(fbGraphUrl('me', 'fields=name,id,email'), function (error, response, body) {
+            if (!error && response.statusCode == 200) {
+                var fbUser_1 = JSON.parse(body);
+                request.get(fbGraphUrl(fbUser_1.id + "/picture", 'height=100'), function (error, response, body) {
+                    if (!error && response.statusCode == 200) {
+                        var imgUrl = response.request.uri.href;
+                        var card = new builder.ThumbnailCard()
+                            .title(fbUser_1.name)
+                            .subtitle(fbUser_1.email)
+                            .images([new builder.CardImage().url(imgUrl)]);
+                        callback(card);
+                    }
+                    else {
+                        callback(null);
+                    }
+                });
+            }
+            else {
+                callback(null);
+            }
+        });
+    };
+    SimpleFBAuth.prototype.parseCookie = function (rawCookie) {
+        var cookies = {};
+        if (rawCookie) {
+            var c = rawCookie.split('; ');
+            for (var i = c.length - 1; i >= 0; i--) {
+                var v = c[i].split('=');
+                cookies[v[0]] = v[1];
+            }
+        }
+        return cookies;
+    };
+    SimpleFBAuth.prototype.encryptState = function (state) {
+        var cipher = crypto.createCipher('aes192', this.settings.fbAppClientSecret);
+        var encryptedState = cipher.update(JSON.stringify(state), 'utf8', 'base64');
+        encryptedState += cipher.final('base64');
+        return encryptedState;
+    };
+    SimpleFBAuth.prototype.decryptState = function (rawState) {
+        var decipher = crypto.createDecipher('aes192', this.settings.fbAppClientSecret);
+        var state = decipher.update(rawState, 'base64', 'utf8');
+        state += decipher.final('utf8');
+        var parsedState = JSON.parse(state);
+        return parsedState;
+    };
+    // Endpoints used in this service
+    SimpleFBAuth.AuthStartPath = "/auth/start";
+    SimpleFBAuth.AuthStartOAuthPath = "/auth/oauth";
+    SimpleFBAuth.AuthCallbackPath = "/auth/callback";
+    SimpleFBAuth.TeamsSDK = 'https://statics.teams.microsoft.com/sdk/v1.0/js/MicrosoftTeams.min.js';
+    return SimpleFBAuth;
+}());
+exports.SimpleFBAuth = SimpleFBAuth;

--- a/Node/samples/simpleFBAuth.ts
+++ b/Node/samples/simpleFBAuth.ts
@@ -1,0 +1,296 @@
+import * as teams from 'botbuilder-teams';
+import * as builder from 'botbuilder';
+import * as restify from 'restify';
+import * as crypto from 'crypto';
+import * as request from 'request';
+
+export interface IFacebookAppSigninSettings {
+  baseUrl: string,
+  fbAppClientId: string,
+  fbAppClientSecret: string,
+  fbAppScope: string
+}
+
+interface ISigninState {
+  userId: string,
+  accessCode: string,
+  channelId?: string
+}
+
+export class SimpleFBAuth
+{  
+  // Endpoints used in this service
+  private static readonly AuthStartPath: string = "/auth/start";
+  private static readonly AuthStartOAuthPath: string = "/auth/oauth";
+  private static readonly AuthCallbackPath: string = "/auth/callback";
+  private static readonly TeamsSDK: string = 'https://statics.teams.microsoft.com/sdk/v1.0/js/MicrosoftTeams.min.js';
+
+  private static instance: SimpleFBAuth;
+  private settings: IFacebookAppSigninSettings;
+  private connector: teams.TeamsChatConnector;
+  private userIdFacebookTokenCache: {[userId: string]: string} = {};
+
+  public static create(server: any, connector: teams.TeamsChatConnector, settings: IFacebookAppSigninSettings) {
+    if (!SimpleFBAuth.instance) {
+      SimpleFBAuth.instance = new SimpleFBAuth(server);
+    }
+    SimpleFBAuth.instance.connector = connector;
+    SimpleFBAuth.instance.settings = settings;
+    return SimpleFBAuth.instance;
+  }
+
+  private constructor(server: any) {
+    server.use(restify.queryParser());    
+    server.get(SimpleFBAuth.AuthStartPath + '/:userId', (req, res, next) => this.authStart(req, res, next));
+    server.get(SimpleFBAuth.AuthCallbackPath, (req, res, next) => this.authCallback(req, res, next));
+    server.get(SimpleFBAuth.AuthStartOAuthPath, (req, res, next) => this.authStartOAuth(req, res, next));
+  }
+
+  public botSignIn(session: builder.Session): void {
+    let userId = session.message.address.user.id;
+    let issueNewCard = () => {
+      let authUrl = this.settings.baseUrl + SimpleFBAuth.AuthStartPath + '/' + userId;
+      let card = new builder.SigninCard(session).text('Sign in Facebook app').button('Login', authUrl);
+      let msg = new builder.Message(session).attachments([card]);
+      session.send(msg);
+      session.endDialog();        
+    };
+    
+    if (this.userIdFacebookTokenCache[ userId ]) {
+      // Use cached token
+      let token = this.userIdFacebookTokenCache[ userId ];
+
+      // Send a thumbnail card with user's FB profile
+      this.CreateFBProfileCard(token, card => {
+        if (card) {
+          let msg = new builder.Message(session)
+                   .text('Cached credential is found. Use cached token to fetch info.')
+                   .attachments([card]);
+          session.send(msg);
+          session.endDialog();
+        } else {
+          // Token is invalid to fetch info (i.e., expired)
+          issueNewCard();
+        }
+      });
+    } else {
+      // No token cached: issue a new Signin card
+      issueNewCard();
+    }
+  }
+
+  public botSignOut(session: builder.Session): void {
+    let userId = session.message.address.user.id;    
+    delete this.userIdFacebookTokenCache[ userId ];
+    let msg = new builder.Message(session).text('Your cached credential has been removed.');
+    session.send(msg);
+    session.endDialog();
+  }
+
+  public verifySigninState(event: builder.IEvent, 
+                           query: teams.ISigninStateVerificationQuery, 
+                           callback: (err: Error, result: any, statusCode?: number) => void) {
+
+    let sendMessage = (text?: string, card?: builder.AttachmentType) => {
+      let msg = new builder.Message().address(event.address);
+      if (text) {
+        msg.text(text);
+      }
+      if (card) {
+        msg.attachments([card]);
+      }
+      this.connector.send([msg.toMessage()], null);
+    };
+
+    // Decrypt state string to get code and original userId & channelId
+    let state = this.decryptState(query.state);
+    let trustableUserId = event.address.user.id;
+    let trustableChannelId = event.sourceEvent.channel && event.sourceEvent.channel.id;
+    let invalidUserId = state.userId !== trustableUserId;
+    let invalidChannelId = state.channelId && trustableChannelId && state.channelId !== trustableChannelId;
+
+    // Verify userId & channelId
+    if (invalidUserId || invalidChannelId) {
+      sendMessage('Unauthorized: User ID verification failed. Please try again.');
+      callback(new Error('User ID verification failed'), null, 401);
+      return;
+    } else {
+      // Prepare FB OAuth request
+      let fbAppId = this.settings.fbAppClientId;
+      let fbOAuthRedirectUrl = this.settings.baseUrl + SimpleFBAuth.AuthCallbackPath;
+      let fbAppSecret = this.settings.fbAppClientSecret;
+      let fbOAuthTokenUrl = 'https://graph.facebook.com/v2.10/oauth/access_token';
+      let fbOAuthTokenParams = `?client_id=${fbAppId}&redirect_uri=${fbOAuthRedirectUrl}&client_secret=${fbAppSecret}&code=${state.accessCode}`;
+
+      // Use access code to exchange FB token
+      request.get(fbOAuthTokenUrl + fbOAuthTokenParams, (error, response, body) => {
+        if (!error && response.statusCode == 200) {
+          let tokenObj = JSON.parse(body);
+
+          // Update cache
+          let fbToken = tokenObj['access_token'];
+          this.userIdFacebookTokenCache[ trustableUserId ] = fbToken;
+
+          // Send a thumbnail card with user's FB profile
+          this.CreateFBProfileCard(fbToken, card => {
+            if (card) {
+              sendMessage(null, card);
+              callback(null, null, 200);
+              return;
+            } else {
+              sendMessage('Could not fetch your facebook info. Please try again later.');
+              callback(new Error('Facebook API call failed'), null, 500);
+              return;                  
+            }
+          });
+        } else {
+          sendMessage('Facebook token update failed. Please try again later.');
+          callback(new Error('Facebook token update failed'), null, 500);
+          return;
+        }
+      });
+    }
+  }
+
+  private authStart(req: any, res: any, next: Function) {
+    let userId = req.params.userId;
+    let authUrl = this.settings.baseUrl + SimpleFBAuth.AuthStartOAuthPath;
+    let body = `
+      <html>
+        <head>
+          <script src='${SimpleFBAuth.TeamsSDK}'></script>
+        </head>
+        <body>
+          <script>
+            microsoftTeams.initialize();
+            microsoftTeams.getContext((context) => {
+              //- Save user and channel id to cookie
+              document.cookie = 'userId=' + '${userId}' + '; Path=/';
+              if (context.channelId) {
+                document.cookie = 'channelId=' + context.channelId + ';Path=/';
+              } else {
+                document.cookie = 'channelId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+              }
+              window.location = '${authUrl}';
+            });        
+          </script>
+        </body>
+      </html>
+    `;
+
+    res.writeHead(200, {
+      'Content-Length': Buffer.byteLength(body),
+      'Content-Type': 'text/html'
+    });
+    res.write(body);
+    res.end();
+  }
+
+  private authStartOAuth(req: any, res: any, next: Function) {
+    let fbAppId = this.settings.fbAppClientId;
+    let fbOAuthRedirectUrl = this.settings.baseUrl + SimpleFBAuth.AuthCallbackPath;
+    let fbAppScope = this.settings.fbAppScope;
+    let fbOAuthUrl = `https://www.facebook.com/v2.10/dialog/oauth?client_id=${fbAppId}&redirect_uri=${fbOAuthRedirectUrl}&scope=${fbAppScope}`;
+    res.redirect(fbOAuthUrl, next);
+  }
+
+  private authCallback(req: any, res: any, next: Function) {
+    let onAuthResultBody = (succeeded: boolean, state?: string) => { return succeeded ? `
+      <html>
+        <head>
+          <script src='${SimpleFBAuth.TeamsSDK}'></script>        
+        </head>
+        <body>
+          <script>
+            microsoftTeams.initialize();
+            microsoftTeams.authentication.notifySuccess('${state}');
+          </script>
+        </body>
+      </html>
+      ` : `
+      <html>
+        <head>
+          <script src='${SimpleFBAuth.TeamsSDK}'></script>
+        </head>
+        <body>
+          <script>
+            microsoftTeams.initialize();
+            microsoftTeams.authentication.notifyFailure();
+          </script>
+        </body>
+      </html>
+    `};
+
+    let body: string = '';
+    if (req.query.code) {
+      let cookie = this.parseCookie(req.headers.cookie);
+      let state = <ISigninState> {
+        userId: cookie.userId,
+        accessCode: req.query.code,
+        channelId: cookie.channelId
+      };
+      body = onAuthResultBody(true, this.encryptState(state));
+    } else {
+      body = onAuthResultBody(false);
+    }
+
+    (<any> res).writeHead(200, {
+      'Content-Length': Buffer.byteLength(body),
+      'Content-Type': 'text/html'
+    });
+    res.write(body);
+    res.end();
+  }
+
+  private CreateFBProfileCard(fbToken: string, callback: Function) {
+    // Use FB token to perform graph API to fetch user FB information
+    let fbGraphUrl = (endPoint: string, params: string) => 'https://graph.facebook.com/' + endPoint + `?access_token=${fbToken}&` + params;
+  
+    request.get(fbGraphUrl('me', 'fields=name,id,email'), (error, response, body) => {
+      if (!error && response.statusCode == 200) {
+        let fbUser = JSON.parse(body);
+        request.get(fbGraphUrl(`${fbUser.id}/picture`, 'height=100'), (error, response, body) => {
+          if (!error && response.statusCode == 200) {
+            let imgUrl = response.request.uri.href;
+            let card = new builder.ThumbnailCard()
+                      .title(fbUser.name)
+                      .subtitle(fbUser.email)
+                      .images([new builder.CardImage().url(imgUrl)]);
+            callback(card);
+          } else {
+            callback(null);
+          }
+        });
+      } else {
+        callback(null);
+      }
+    });
+  }
+
+  private parseCookie(rawCookie: string): any {
+    let cookies: any = {};
+    if (rawCookie) {
+      let c = rawCookie.split('; ');
+      for (let i = c.length - 1; i >= 0; i--) {
+        let v = c[i].split('=');
+        cookies[ v[0] ] = v[1];
+     }
+    }
+    return cookies;
+  }
+
+  private encryptState(state: ISigninState): string {
+    const cipher = crypto.createCipher('aes192', this.settings.fbAppClientSecret);
+    let encryptedState = cipher.update(JSON.stringify(state), 'utf8', 'base64');
+    encryptedState += cipher.final('base64');
+    return encryptedState;
+  }
+
+  private decryptState(rawState: string): ISigninState {
+    const decipher = crypto.createDecipher('aes192', this.settings.fbAppClientSecret);
+    let state = decipher.update(rawState, 'base64', 'utf8');
+    state += decipher.final('utf8');
+    let parsedState = JSON.parse(state);
+    return parsedState;
+  }
+}

--- a/Node/src/botbuilder-teams.d.ts
+++ b/Node/src/botbuilder-teams.d.ts
@@ -790,6 +790,17 @@ export declare class O365ConnectorCardMultichoiceInputChoice implements IIsO365C
 }
 
 /**
+ * @interface
+ * Interface of signin auth state verfication query
+ * 
+ * @member {string} [state] The state string originally received when the signin web flow is finished with a state posted back to client via tab SDK microsoftTeams.authentication.notifySuccess(state)
+ *  
+ */
+export interface ISigninStateVerificationQuery {
+  state: string;
+}
+
+/**
  * @class
  * Initializes a new instance of the ComposeExtensionQueryOptions class.
  * @constructor
@@ -980,8 +991,9 @@ export declare class TenantInfo {
   constructor(id: string);
 }
 
-export type ComposeExtensionHandlerType = (event: builder.IEvent, query: ComposeExtensionQuery, callback: (err: Error, result: IComposeExtensionResponse, statusCode: number) => void) => void;
-export type O365ConnectorCardActionHandlerType = (event: builder.IEvent, query: IO365ConnectorCardActionQuery, callback: (err: Error, result: any, statusCode: number) => void) => void;
+export type ComposeExtensionHandlerType = (event: builder.IEvent, query: ComposeExtensionQuery, callback: (err: Error, result: IComposeExtensionResponse, statusCode?: number) => void) => void;
+export type O365ConnectorCardActionHandlerType = (event: builder.IEvent, query: IO365ConnectorCardActionQuery, callback: (err: Error, result: any, statusCode?: number) => void) => void;
+export type SigninStateVerificationHandlerType = (event: builder.IEvent, query: ISigninStateVerificationQuery, callback: (err: Error, result: any, statusCode?: number) => void) => void;
 
 export interface IInvokeEvent extends builder.IEvent {
   name: string;
@@ -1054,6 +1066,11 @@ export class TeamsChatConnector extends builder.ChatConnector {
   */
   public onO365ConnectorCardAction(handler: O365ConnectorCardActionHandlerType): void;
 
+  /**
+  *  Set a handler to verify the final state sent by client that is originally received from signin web flow when it's finished
+  */
+  public onSigninStateVerification(handler: SigninStateVerificationHandlerType): void;
+  
   /**
   *  Set a handler by commandId of a compose extension query
   */

--- a/Node/src/models/index.d.ts
+++ b/Node/src/models/index.d.ts
@@ -458,6 +458,17 @@ export interface IO365ConnectorCardActionQuery {
 }
 
 /**
+ * @interface
+ * Interface of signin auth state verfication query
+ * 
+ * @member {string} [state] The state string originally received when the signin web flow is finished with a state posted back to client via tab SDK microsoftTeams.authentication.notifySuccess(state)
+ *  
+ */
+export interface ISigninStateVerificationQuery {
+  state: string;
+}
+
+/**
  * @class
  * Initializes a new instance of the ComposeExtensionQueryOptions class.
  * @constructor


### PR DESCRIPTION
As part of Signin action auth flow, the final state posted back to clients from web flow though microsoftTeams.authentication.notifySuccess() will be sent back to bots via an invoke call, so as to make bots be able to verify the final state and complete the signin flow. As this step can be regarded as the final step of overall signin flow, a suggested practice is to update token cache after verification.