### PR TITLE
Ignore endOfCoversation message types

### DIFF
--- a/Node/src/TeamsChatConnector.ts
+++ b/Node/src/TeamsChatConnector.ts
@@ -237,6 +237,16 @@ export class TeamsChatConnector extends builder.ChatConnector {
   }
 
   /**
+  * @override
+  *
+  * Change default implementation to ignore endOfCoversation message types
+  *
+  */
+  public send(messages: builder.IMessage[], done: (err: Error, addresses?: builder.IAddress[]) => void): void {
+    return super.send(messages.filter((m) => m.type !== "endOfConversation"), done)
+  }
+
+  /**
   *  Set the list of allowed tenants. Messages from tenants not on the list will be dropped silently.
   *  @param {array} tenants - Ids of allowed tenants.
   */


### PR DESCRIPTION
Based on comments in github, endOfCoversation is not supported in Teams.
This change will ignore this type of message to prevent errors.

https://github.com/Microsoft/BotBuilder/issues/3379