### PR TITLE
Moving nodemon to devDependencies

### DIFF
--- a/Node/package.json
+++ b/Node/package.json
@@ -13,12 +13,12 @@
     "botbuilder": "^3.11.0",
     "crypto": "^1.0.1",
     "ms-rest": "^1.15.7",
-    "nodemon": "^1.12.1",
     "sprintf-js": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^7.0.43",
     "@types/sprintf-js": "0.0.27",
+    "nodemon": "^1.12.1",
     "mocha": "^2.4.5",
     "restify": "^4.3.1",
     "typescript": "^2.5.3"


### PR DESCRIPTION
See https://github.com/OfficeDev/BotBuilder-MicrosoftTeams/issues/96

I'm not equipped to verify this change but given the nature of it it seems pretty safe. 