### PR TITLE
Defer to the generic invoke handler when there is no specific handler.

### DIFF
--- a/Node/package.json
+++ b/Node/package.json
@@ -1,9 +1,10 @@
 {
   "name": "botbuilder-teams",
   "version": "0.1.6",
-  "description": "Microsoft Teams Botbuilder extension SDK",
+  "description": "Microsoft Teams Bot Builder extension SDK",
   "scripts": {
-    "test": "mocha"
+    "prepublish": "cd src && tsc && copy botbuilder-teams.d.ts ..\\lib",
+    "test": "cd test && mocha ."
   },
   "author": "Microsoft Corp",
   "license": "MIT",

--- a/Node/src/models/o365ConnectorCard.ts
+++ b/Node/src/models/o365ConnectorCard.ts
@@ -291,7 +291,6 @@ export abstract class O365ConnectorCardActionBase implements teams.IIsO365Connec
     protected data = <teams.IO365ConnectorCardActionBase>{}
     
     constructor(protected session?: builder.Session) {
-        this.data.type = this.type;
     }
 
     public name(text: string|string[], ...args: any[]): this {
@@ -315,6 +314,7 @@ export abstract class O365ConnectorCardActionBase implements teams.IIsO365Connec
     protected abstract get type(): string;
 
     public toAction(): teams.IO365ConnectorCardActionBase {
+        this.data.type = this.type;
         return this.data;
     }
 }
@@ -469,7 +469,6 @@ export abstract class O365ConnectorCardInputBase implements teams.IIsO365Connect
     protected data = <teams.IO365ConnectorCardInputBase>{};
 
     constructor(protected session?: builder.Session) {
-        this.data.type = this.type;
     }
 
     public id(inputId: string): this {
@@ -507,6 +506,7 @@ export abstract class O365ConnectorCardInputBase implements teams.IIsO365Connect
     protected abstract get type(): string;
 
     public toInput(): teams.IO365ConnectorCardInputBase {
+        this.data.type = this.type;
         return this.data;
     }
 }

--- a/Node/src/tsconfig.json
+++ b/Node/src/tsconfig.json
@@ -11,5 +11,6 @@
         "forceConsistentCasingInFileNames": true
     },
     "exclude": [
+        "botbuilder-teams.d.ts"
     ]
 }

--- a/Node/test/TeamsChatConnector.js
+++ b/Node/test/TeamsChatConnector.js
@@ -1,0 +1,310 @@
+let builder = require('botbuilder');
+let assert = require('assert');
+let lib = require('../lib/TeamsChatConnector');
+
+describe('TeamsChatConnector', function () {
+
+  describe('#onQuery()', function () {
+    it('should receive compose extension query events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onQuery('myCommandId', (event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.queryInvokeName,
+          value: {
+            commandId: 'myCommandId'
+          }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onQuery handler was not called');
+        done();
+      })
+    });
+
+    it('should fail if handlers were registered but not for the given command id', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onQuery('myCommandId', (event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.queryInvokeName,
+          value: {
+            commandId: 'differentCommandId'
+          }
+        }
+      ], (err, body, status) => {
+        assert.ok(err, 'Dispatch succeeded even when no handler was registered for the given command id');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no handlers were registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.queryInvokeName,
+          value: {
+            commandId: 'myCommandId'
+          }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+  describe('#onQuerySettingsUrl()', function () {
+    it('should receive compose extension query settings url events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onQuerySettingsUrl((event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.querySettingUrlInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onQuerySettingsUrl handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onQuerySettingsUrl handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.querySettingUrlInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+  describe('#onSettingsUpdate()', function () {
+    it('should receive compose extension settings update events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onSettingsUpdate((event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.settingInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onSettingsUpdate handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onSettingsUpdate handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.settingInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+  describe('#onSelectItem()', function () {
+    it('should receive compose extension select item events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onSelectItem((event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.selectItemInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onSelectItem handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onSelectItem handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.selectItemInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+  describe('#onO365ConnectorCardAction()', function () {
+    it('should receive O365 connector card action events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onO365ConnectorCardAction((event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.o365CardActionInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onO365ConnectorCardAction handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onO365ConnectorCardAction handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.o365CardActionInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+  describe('#onSigninStateVerification()', function () {
+    it('should receive signin state verification events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onSigninStateVerification((event, query, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.signinStateVerificationInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onSigninStateVerification handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onSigninStateVerification handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.signinStateVerificationInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
+
+});


### PR DESCRIPTION
* If a specific handler for an invoke is not found, defer to the onInvoke handler instead of failing. This makes package upgrades easier; previously, existing code could break when we add a new handler.
* Unit tests for new functionality
* Fix typescript compiler error in O365 connector card models.

Fix for #92 