### PR TITLE
Update call to queryParser for compatibility with Restify v5

### DIFF
--- a/Node/samples/simpleFBAuth.ts
+++ b/Node/samples/simpleFBAuth.ts
@@ -40,7 +40,7 @@ export class SimpleFBAuth
   }
 
   private constructor(server: any) {
-    server.use(restify.queryParser());    
+    server.use(restify.plugins.queryParser());    
     server.get(SimpleFBAuth.AuthStartPath + '/:userId', (req, res, next) => this.authStart(req, res, next));
     server.get(SimpleFBAuth.AuthCallbackPath, (req, res, next) => this.authCallback(req, res, next));
     server.get(SimpleFBAuth.AuthStartOAuthPath, (req, res, next) => this.authStartOAuth(req, res, next));


### PR DESCRIPTION
Update call to queryParser for compatibility with Restify v5:
- server.use(restify.bodyParser()); is deprecated
- Replace with server.use(restify.plugins.bodyParser());
See restify changelog for details : https://github.com/restify/node-restify/blob/master/CHANGES.md