### PR TITLE
Support files in bots in the Node.js SDK

### DIFF
--- a/Node/src/botbuilder-teams.d.ts
+++ b/Node/src/botbuilder-teams.d.ts
@@ -875,6 +875,7 @@ export interface IInvokeEvent extends builder.IEvent {
 export type ComposeExtensionHandlerType = (event: builder.IEvent, query: ComposeExtensionQuery, callback: (err: Error, result: IComposeExtensionResponse, statusCode?: number) => void) => void;
 export type O365ConnectorCardActionHandlerType = (event: builder.IEvent, query: IO365ConnectorCardActionQuery, callback: (err: Error, result: any, statusCode?: number) => void) => void;
 export type SigninStateVerificationHandlerType = (event: builder.IEvent, query: ISigninStateVerificationQuery, callback: (err: Error, result: any, statusCode?: number) => void) => void;
+export type FileConsentCardResponseHandlerType = (event: builder.IEvent, response: IFileConsentCardResponse, callback: (err: Error, result: any, statusCode?: number) => void) => void;
 
 /** Specialization of the ChatConnector for Microsoft Teams. */
 export class TeamsChatConnector extends builder.ChatConnector {
@@ -979,6 +980,12 @@ export class TeamsChatConnector extends builder.ChatConnector {
   *  @param handler The function to execute when a compose extension select item invoke activity is received.
   */
   public onSelectItem(handler: ComposeExtensionHandlerType): void;
+
+  /**
+  *  Set a handler that is called when the response to a file consent card is received .
+  *  @param handler The function to execute when a file consent card invoke activity is received.
+  */
+  public onFileConsentCardResponse(handler: FileConsentCardResponseHandlerType): void;
 }
 
 /**
@@ -1095,4 +1102,117 @@ export class TeamMention extends MentionEntity {
     *  @param {TeamInfo} team - Team to mention. Both team.id and team.name are required. You can get the name from the fetchTeamInfo API, or use a generic name like 'team'.
     */
     constructor(team: TeamInfo);
+}
+
+
+/**
+ * File consent card builder class.
+ */
+export class FileConsentCard implements builder.IIsAttachment {
+
+  /** Creates a new file consent card builder. */
+  constructor(private session?: builder.Session);
+
+  /** Name of the file. */
+  public name(name: string): FileConsentCard;
+
+  /** Description of the file. */
+  public description(description: string, ...args: any[]): FileConsentCard;
+
+  /** Approximate size of the file in bytes. */
+  public sizeInBytes(sizeInBytes: number): FileConsentCard;
+
+  /** Context to return if the user accepts the proposed file upload. */
+  public acceptContext(context: any): FileConsentCard;
+
+  /** Context to return if the user declines the proposed file upload. */
+  public declineContext(context: any): FileConsentCard;
+
+  /** 
+   * Context to return whether the user accepts or declines the proposed file upload. 
+   * Shorthand for calls to `acceptContext(context)` and `declineContext(context)` with the same value.
+   */
+  public context(context: any): FileConsentCard;
+}
+
+/** Represents the value of the invoke activity sent when the user acts on a file consent card. */
+export interface IFileConsentCardResponse {
+
+  /** The action the user took. */
+  action: FileConsentCardAction;
+
+  /** The context associated with the action. */
+  context?: any;
+
+  /** If the user accepted the file, contains information about the file to be uploaded. */
+  uploadInfo?: IFileUploadInfo;
+}
+
+/** Actions the user can take on the file consent card. */
+export enum FileConsentCardAction {
+
+  /** File was accepted. */
+  accept = "accept",
+
+  /** File was declined. */
+  decline = "decline",
+}
+
+/** Represents a file download info attachment. */
+export interface IFileDownloadInfo extends builder.IAttachment {
+
+  /** The additional content of the attachment. */
+  content: IFileDownloadInfoContent;
+}
+
+/** Additional content of a file download info attachment. */
+export interface IFileDownloadInfoContent {
+
+  /** Type of the file. */
+  fileType: string;
+
+  /** Short-lived download url for the file. */
+  downloadUrl: string;    
+}
+
+/**
+* Helpers for working with file download info attachments.
+*/
+export class FileDownloadInfo {
+
+  /** Content type of a file download info attachment. */
+  public static contentType = "application/vnd.microsoft.teams.file.download.info";
+
+  /**
+   * Returns the attachments in the list that are of type file download info.
+   * @param attachments the attachments in the message
+   */
+  public static filter(attachments: builder.IAttachment[]|undefined): IFileDownloadInfo[]|undefined;
+}
+
+/**
+ * File info card builder class.
+ */
+export class FileInfoCard implements builder.IIsAttachment {
+
+  /** Creates a new file info card builder. */
+  constructor(private session?: builder.Session);
+
+  /** Name of the file. */
+  public name(name: string): FileInfoCard;
+
+  /** URL to the file. */
+  public contentUrl(url: string): FileInfoCard;
+
+  /** Unique ID of the file. */
+  public uniqueId(uniqueId: string): FileInfoCard;
+
+  /** Type of the file. */
+  public fileType(fileType: string): FileInfoCard;
+
+  /**
+   * Creates a file info card from the data in a `IFileUploadInfo` object.
+   * @param uploadInfo The object containing the information that should be used to populate the card.
+   */
+  public static fromFileUploadInfo(uploadInfo: IFileUploadInfo): FileInfoCard;
 }

--- a/Node/src/botbuilder-teams.ts
+++ b/Node/src/botbuilder-teams.ts
@@ -64,3 +64,7 @@ export { ChannelCreatedEvent } from './ConversationUpdate';
 export { ChannelDeletedEvent } from './ConversationUpdate';
 export { ChannelRenamedEvent } from './ConversationUpdate';
 export { TeamRenamedEvent } from './ConversationUpdate';
+export * from './models/FileConsentCard';
+export * from './models/FileConsentCardResponse';
+export * from './models/FileDownloadInfo';
+export * from './models/FileInfoCard';

--- a/Node/src/models/FileConsentCard.ts
+++ b/Node/src/models/FileConsentCard.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as builder from "botbuilder";
+
+/**
+ * File consent card builder class.
+ */
+export class FileConsentCard implements builder.IIsAttachment {
+
+    /** Internal attachment object being built. */
+    private data: builder.IAttachment = {
+        contentType: "application/vnd.microsoft.teams.card.file.consent",
+        content: { }
+    };
+
+    /** Creates a new file consent card builder. */
+    constructor(private session?: builder.Session) {
+    }
+
+    /** Name of the file. */
+    public name(name: string): FileConsentCard {
+        this.data.name = name;
+        return this;
+    }
+
+    /** Description of the file. */
+    public description(description: string, ...args: any[]): FileConsentCard {
+        if (this.session) {
+            description = this.session.gettext(description, args);
+        }
+        this.data.content.description = description;
+        return this;
+    }
+
+    /** Approximate size of the file in bytes. */
+    public sizeInBytes(sizeInBytes: number): FileConsentCard {
+        if (sizeInBytes < 0) {
+            throw new Error("sizeInBytes must be greater than or equal to 0.");
+        }
+        this.data.content.sizeInBytes = sizeInBytes;
+        return this;
+    }
+
+    /** Context to return if the user accepts the proposed file upload. */
+    public acceptContext(context: any): FileConsentCard {
+        this.data.content.acceptContext = context;
+        return this;
+    }
+
+    /** Context to return if the user declines the proposed file upload. */
+    public declineContext(context: any): FileConsentCard {
+        this.data.content.declineContext = context;
+        return this;
+    }
+
+    /** 
+     * Context to return whether the user accepts or declines the proposed file upload. 
+     * Shorthand for calls to `acceptContext(context)` and `declineContext(context)` with the same value.
+     */
+    public context(context: any): FileConsentCard {
+        this.data.content.acceptContext = context;
+        this.data.content.declineContext = context;
+        return this;
+    }
+
+    /** Returns the JSON object for the attachment. */
+    toAttachment(): builder.IAttachment {
+        return this.data;
+    }
+}

--- a/Node/src/models/FileConsentCard.ts
+++ b/Node/src/models/FileConsentCard.ts
@@ -63,13 +63,13 @@ export class FileConsentCard implements builder.IIsAttachment {
     }
 
     /** Context to return if the user accepts the proposed file upload. */
-    public acceptContext(context: any): FileConsentCard {
+    public acceptContext(context: object): FileConsentCard {
         this.data.content.acceptContext = context;
         return this;
     }
 
     /** Context to return if the user declines the proposed file upload. */
-    public declineContext(context: any): FileConsentCard {
+    public declineContext(context: object): FileConsentCard {
         this.data.content.declineContext = context;
         return this;
     }
@@ -78,9 +78,9 @@ export class FileConsentCard implements builder.IIsAttachment {
      * Context to return whether the user accepts or declines the proposed file upload. 
      * Shorthand for calls to `acceptContext(context)` and `declineContext(context)` with the same value.
      */
-    public context(context: any): FileConsentCard {
-        this.data.content.acceptContext = context;
-        this.data.content.declineContext = context;
+    public context(context: object): FileConsentCard {
+        this.acceptContext(context);
+        this.declineContext(context);
         return this;
     }
 

--- a/Node/src/models/FileConsentCardResponse.ts
+++ b/Node/src/models/FileConsentCardResponse.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as builder from "botbuilder";
+
+/** Name of the file consent invoke activity */
+export const fileConsentInvokeName = "fileConsent/invoke";
+
+/** Represents the value of the invoke activity sent when the user acts on a file consent card. */
+export interface IFileConsentCardResponse {
+
+    /** The action the user took. */
+    action: FileConsentCardAction;
+
+    /** The context associated with the action. */
+    context?: any;
+
+    /** If the user accepted the file, contains information about the file to be uploaded. */
+    uploadInfo?: IFileUploadInfo;
+}
+
+/** Actions the user can take on the file consent card. */
+export enum FileConsentCardAction {
+
+    /** File was accepted. */
+    accept = "accept",
+
+    /** File was declined. */
+    decline = "decline",
+}
+
+/** Information about the file to be uploaded. */
+export interface IFileUploadInfo {
+
+    /** Name of the file. */
+    name: string;
+
+    /** URL to an upload session that the bot can use to set the file contents. */
+    uploadUrl: string;
+
+    /** URL to file. */
+    contentUrl: string;
+
+    /** ID that uniquely identifies the file. */
+    uniqueId: string;
+
+    /** Type of the file. */
+    fileType: string;
+}

--- a/Node/src/models/FileDownloadInfo.ts
+++ b/Node/src/models/FileDownloadInfo.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as builder from "botbuilder";
+
+/** Represents a file download info attachment. */
+export interface IFileDownloadInfo extends builder.IAttachment {
+
+    /** The additional content of the attachment. */
+    content: IFileDownloadInfoContent;
+}
+
+/** Additional content of a file download info attachment. */
+export interface IFileDownloadInfoContent {
+
+    /** Type of the file. */
+    fileType: string;
+
+    /** Short-lived download url for the file. */
+    downloadUrl: string;    
+}
+
+/**
+ * Helpers for working with file download info attachments.
+ */
+export class FileDownloadInfo {
+
+    /** Content type of a file download info attachment. */
+    public static contentType = "application/vnd.microsoft.teams.file.download.info";
+
+    /**
+     * Returns the attachments in the list that are of type file download info.
+     * @param attachments the attachments in the message
+     */
+    public static filter(attachments: builder.IAttachment[]|undefined): IFileDownloadInfo[]|undefined {
+        if (attachments) {
+            return attachments.filter(x => x.contentType === FileDownloadInfo.contentType) as IFileDownloadInfo[];
+        } else {
+            return undefined;
+        }
+    }    
+}

--- a/Node/src/models/FileInfoCard.ts
+++ b/Node/src/models/FileInfoCard.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as builder from "botbuilder";
+import { IFileUploadInfo } from "./FileConsentCardResponse";
+
+/**
+ * File info card builder class.
+ */
+export class FileInfoCard implements builder.IIsAttachment {
+
+    /** Internal attachment object being built. */
+    private data: builder.IAttachment = {
+        contentType: "application/vnd.microsoft.teams.card.file.info",
+        content: { }
+    };
+
+    /** Creates a new file info card builder. */
+    constructor(private session?: builder.Session) {
+    }
+
+    /** Name of the file. */
+    public name(name: string): FileInfoCard {
+        this.data.name = name;
+        return this;
+    }
+
+    /** URL to the file. */
+    public contentUrl(url: string): FileInfoCard {
+        this.data.contentUrl = url;
+        return this;
+    }
+
+    /** Unique ID of the file. */
+    public uniqueId(uniqueId: string): FileInfoCard {
+        this.data.content.uniqueId = uniqueId;
+        return this;
+    }
+
+    /** Type of the file. */
+    public fileType(fileType: string): FileInfoCard {
+        this.data.content.fileType = fileType;
+        return this;
+    }
+
+    /** Returns the JSON object for the attachment. */
+    toAttachment(): builder.IAttachment {
+        return this.data;
+    }
+
+    /**
+     * Creates a file info card from the data in a `IFileUploadInfo` object. 
+     * @param uploadInfo The object containing the information that should be used to populate the card.
+     */
+    public static fromFileUploadInfo(uploadInfo: IFileUploadInfo): FileInfoCard {
+        return new FileInfoCard()
+            .name(uploadInfo.name)
+            .contentUrl(uploadInfo.contentUrl)
+            .uniqueId(uploadInfo.uniqueId)
+            .fileType(uploadInfo.fileType);
+    }
+}

--- a/Node/test/FileConsentCard.js
+++ b/Node/test/FileConsentCard.js
@@ -1,0 +1,42 @@
+var assert = require('assert');
+var fcc = require('../lib/models/FileConsentCard');
+
+describe('FileConsentCard', function () {
+  describe('#toAttachment()', function (done) {
+    it('should populate attachment correctly', function () {
+      let card = new fcc.FileConsentCard()
+        .name('filename.txt')
+        .description('file description')
+        .sizeInBytes(1000)
+        .acceptContext({ data: 'accept' })
+        .declineContext({ data: 'decline' });
+
+      let attachment = card.toAttachment();
+      assert(attachment.contentType === 'application/vnd.microsoft.teams.card.file.consent');
+      assert(attachment.name === 'filename.txt');
+      assert(attachment.content.description === 'file description');
+      assert(attachment.content.sizeInBytes === 1000);
+      assert(attachment.content.acceptContext.data === 'accept');
+      assert(attachment.content.declineContext.data === 'decline');
+    });
+  });
+
+  describe('#context()', function (done) {
+    it('should set accept and decline context', function () {
+      let card = new fcc.FileConsentCard()
+        .name('filename.txt')
+        .description('file description')
+        .sizeInBytes(1000)
+        .acceptContext({ data: 'neutral' })
+        .declineContext({ data: 'neutral' });
+
+      let attachment = card.toAttachment();
+      assert(attachment.contentType === 'application/vnd.microsoft.teams.card.file.consent');
+      assert(attachment.name === 'filename.txt');
+      assert(attachment.content.description === 'file description');
+      assert(attachment.content.sizeInBytes === 1000);
+      assert(attachment.content.acceptContext.data === 'neutral');
+      assert(attachment.content.declineContext.data === 'neutral');
+    });
+  });
+});

--- a/Node/test/FileInfoCard.js
+++ b/Node/test/FileInfoCard.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var fic = require('../lib/models/FileInfoCard');
+
+describe('FileInfoCard', function () {
+  describe('#toAttachment()', function (done) {
+    it('should populate attachment correctly', function () {
+      let card = new fic.FileInfoCard()
+        .name('filename.txt')
+        .contentUrl('https://content.url')
+        .uniqueId('unique_id')
+        .fileType('txt');
+
+      let attachment = card.toAttachment();
+      assert(attachment.contentType === 'application/vnd.microsoft.teams.card.file.info');
+      assert(attachment.name === 'filename.txt');
+      assert(attachment.contentUrl === 'https://content.url');
+      assert(attachment.content.uniqueId === 'unique_id');
+      assert(attachment.content.fileType === 'txt');
+    });
+  });
+
+  describe('#fromFileUploadInfo()', function (done) {
+    it('should populate attachment correctly', function () {
+      let uploadInfo = {
+        name: 'filename.txt',
+        contentUrl: 'https://content.url',
+        uploadUrl: 'https://upload.url',
+        uniqueId: 'unique_id',
+        fileType: 'txt'
+      };
+      let card = fic.FileInfoCard.fromFileUploadInfo(uploadInfo);
+
+      let attachment = card.toAttachment();
+      assert(attachment.contentType === 'application/vnd.microsoft.teams.card.file.info');
+      assert(attachment.name === 'filename.txt');
+      assert(attachment.contentUrl === 'https://content.url');
+      assert(attachment.content.uniqueId === 'unique_id');
+      assert(attachment.content.fileType === 'txt');
+    });
+  });
+});

--- a/Node/test/TeamsChatConnector.js
+++ b/Node/test/TeamsChatConnector.js
@@ -307,4 +307,49 @@ describe('TeamsChatConnector', function () {
     });
   });
 
+  describe('#onFileConsent()', function () {
+    it('should receive file consent events', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onFileConsentCardResponse((event, response, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.fileConsentInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onFileConsentCardResponse handler was not called');
+        done();
+      })
+    });
+
+    it('should call invoke handler if no onFileConsentCardResponse handler was registered', function (done) {
+      let connector = new lib.TeamsChatConnector({});
+
+      let wasHandlerCalled = false;
+      connector.onInvoke((event, cb) => {
+        wasHandlerCalled = true;
+        cb(null, {}, 200);
+      });
+
+      connector.onDispatchEvents([
+        {
+          type: 'invoke',
+          name: lib.TeamsChatConnector.fileConsentInvokeName,
+          value: { }
+        }
+      ], (err, body, status) => {
+        assert.ok(!err, 'An error occurred: ' + err);
+        assert.ok(wasHandlerCalled, 'The registered onInvoke handler was not called');
+        done();
+      })
+    });
+  });
 });


### PR DESCRIPTION
- Add types for file download info, file consent card, consent card response, and file info card.
- Add handler to TeamsChatConnector for file consent card response.
- Add tests for new functionality.