### PR TITLE
Removing Stylecop Integration and updating nuspec version

### DIFF
--- a/CSharp/Build/SkypeTeams.targets
+++ b/CSharp/Build/SkypeTeams.targets
@@ -3,6 +3,6 @@
     <BuildRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), RootMarker))</BuildRoot>
     <NugetExePath>$(BuildRoot)\Build\Tools\Nuget\NuGet.exe</NugetExePath>
   </PropertyGroup>
-  <Import Project="$(BuildRoot)\Build\SkypeTeams.StyleCop.targets"/>
+  <!-- <Import Project="$(BuildRoot)\Build\SkypeTeams.StyleCop.targets"/> -->
   <Import Project="$(BuildRoot)\Build\SkypeTeams.Tests.targets" Condition="'$(TestProjectType)' == 'UnitTest'"/>
 </Project>

--- a/CSharp/Packager/Microsoft.Bot.Connector.Teams.nuspec
+++ b/CSharp/Packager/Microsoft.Bot.Connector.Teams.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Bot.Connector.Teams</id>
-    <version>0.8.0</version>
+    <version>0.9.0</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/OfficeDev/BotBuilder-MicrosoftTeams/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
Old stylecop does not work with VS2017 anymore. Removing it, since the newer version of nuget has different integration. Will redo the work with 4.x

Updating nuspec version to 0.9.0