### PR TITLE
Fix TeamsChannelAccount parsing on AAD object Id

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/Microsoft.Bot.Connector.Teams.Shared.projitems
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/Microsoft.Bot.Connector.Teams.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FileInfoCardEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetryHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeamsAPI\**\*.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TeamsChannelAccountEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeamsConnectorClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TenantFiltering.cs" />
   </ItemGroup>

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Connector.Teams.Models
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "objectId")]
         public string ObjectId { get; set; }
-        
+
         /// <summary>
         /// Gets or sets given name part of the user name.
         /// </summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
@@ -67,12 +67,6 @@ namespace Microsoft.Bot.Connector.Teams.Models
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "userPrincipalName")]
         public string UserPrincipalName { get; set; }
-        
-        /// <summary>
-        /// Sets the ObjectId property with the value of aadObjectId.
-        /// This is how the AAD object Id is passed from a bot framework message.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "aadObjectId")]
-        private string AADObjectId { set { ObjectId = value; } }
+
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsAPI/Models/TeamsChannelAccount.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Connector.Teams.Models
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "objectId")]
         public string ObjectId { get; set; }
-
+        
         /// <summary>
         /// Gets or sets given name part of the user name.
         /// </summary>
@@ -67,6 +67,12 @@ namespace Microsoft.Bot.Connector.Teams.Models
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "userPrincipalName")]
         public string UserPrincipalName { get; set; }
-
+        
+        /// <summary>
+        /// Sets the ObjectId property with the value of aadObjectId.
+        /// This is how the AAD object Id is passed from a bot framework message.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty(PropertyName = "aadObjectId")]
+        private string AADObjectId { set { ObjectId = value; } }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsChannelAccountEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsChannelAccountEx.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Bot.Connector.Teams.Models
+{
+    /// <summary>
+    /// Teams channel account detailing user Azure Active Directory details.
+    /// </summary>
+    public partial class TeamsChannelAccount
+    {
+        /// <summary>
+        /// Gets or sets unique user principal name
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty(PropertyName = "aadObjectId")]
+        private string AADObjectId { set { ObjectId = value; } }
+    }
+}

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsChannelAccountEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/TeamsChannelAccountEx.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Bot.Connector.Teams.Models
     public partial class TeamsChannelAccount
     {
         /// <summary>
-        /// Gets or sets unique user principal name
+        /// Sets the Azure Active Directory object Id from the other JSON field it can appear in.
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "aadObjectId")]
         private string AADObjectId { set { ObjectId = value; } }

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleActivityConversationUpdateWithAADObjectId.json
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleActivityConversationUpdateWithAADObjectId.json
@@ -1,0 +1,33 @@
+﻿{
+  "membersAdded": [
+    {
+      "id": "29:uniqueId",
+      "aadObjectId": "d2ffaeab-d802-4fec-8580-0987e9ad2628"
+    },
+    {
+      "id": "28:uniqueId"
+    }
+  ],
+  "type": "conversationUpdate",
+  "timestamp": "2018-07-17T03:34:27.521Z",
+  "id": "f:d23bdb9e",
+  "channelId": "msteams",
+  "serviceUrl": "https://smba.trafficmanager.net/amer/",
+  "from": {
+    "id": "29:uniqueId",
+    "aadObjectId": "d2ffaeab-d802-4fec-8580-0987e9ad2628"
+  },
+  "conversation": {
+    "conversationType": "personal",
+    "id": "a:uniqueID"
+  },
+  "recipient": {
+    "id": "28:uniqueId",
+    "name": "Bot Name"
+  },
+  "channelData": {
+    "tenant": {
+      "id": "09e852a2-4575-45f7-9586-7cc3acfdc715"
+    }
+  }
+}

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleActivityMessageWithAADObjectId.json
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleActivityMessageWithAADObjectId.json
@@ -1,0 +1,36 @@
+﻿{
+  "text": "hi",
+  "textFormat": "plain",
+  "type": "message",
+  "timestamp": "2018-07-17T21:11:21.461Z",
+  "localTimestamp": "2018-07-17T14:11:21.461-07:00",
+  "id": "1531861881427",
+  "channelId": "msteams",
+  "serviceUrl": "https://smba.trafficmanager.net/amer/",
+  "from": {
+    "id": "29:uniqueId",
+    "name": "User name",
+    "aadObjectId": "d2ffaeab-d802-4fec-8580-0987e9ad2628"
+  },
+  "conversation": {
+    "conversationType": "personal",
+    "id": "a:uniqueId"
+  },
+  "recipient": {
+    "id": "28:uniqueId",
+    "name": "Bot name"
+  },
+  "entities": [
+    {
+      "locale": "en-US",
+      "country": "US",
+      "platform": "Web",
+      "type": "clientInfo"
+    }
+  ],
+  "channelData": {
+    "tenant": {
+      "id": "09e852a2-4575-45f7-9586-7cc3acfdc715"
+    }
+  }
+}

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Microsoft.Bot.Connector.Teams.Tests.Shared.projitems
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Microsoft.Bot.Connector.Teams.Tests.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SigninAuthTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeamsAPITests.FetchChannelList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeamsAPITests.FetchTeamDetails.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TeamsChannelAccountTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDelegatingHandler.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -54,6 +55,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleActivityInvoke.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleActivityConversationUpdateWithAADObjectId.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleActivityMessageWithAADObjectId.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleActivityNoMentions.json">

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/TeamsChannelAccountTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/TeamsChannelAccountTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+// Microsoft Teams: https://dev.office.com/microsoft-teams
+//
+// Bot Builder SDK GitHub:
+// https://github.com/Microsoft/BotBuilder
+//
+// Bot Builder SDK Extensions for Teams
+// https://github.com/OfficeDev/BotBuilder-MicrosoftTeams
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace Microsoft.Bot.Connector.Teams.Tests.Shared
+{
+    using System.IO;
+
+    using Microsoft.Bot.Connector.Teams.Models;
+    using VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using System.Linq;
+
+    [TestClass]
+    public class TeamsChannelAccountTests
+    {
+        /// <summary>
+        /// Get teams conversation members async test.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromConversationUpdate()
+        {
+            Activity sampleActivity = JsonConvert.DeserializeObject<Activity>(File.ReadAllText(@"Jsons\SampleActivityConversationUpdateWithAADObjectId.json"));
+
+            ChannelAccount user = sampleActivity.From;
+            TeamsChannelAccount teamsUser = user.AsTeamsChannelAccount();
+
+            Assert.IsNotNull(teamsUser);
+            Assert.IsNotNull(teamsUser.ObjectId);
+        }
+
+        /// <summary>
+        /// Get teams conversation members async test.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromMessage()
+        {
+            Activity sampleActivity = JsonConvert.DeserializeObject<Activity>(File.ReadAllText(@"Jsons\SampleActivityMessageWithAADObjectId.json"));
+
+            ChannelAccount user = sampleActivity.From;
+            TeamsChannelAccount teamsUser = user.AsTeamsChannelAccount();
+
+            Assert.IsNotNull(teamsUser);
+            Assert.IsNotNull(teamsUser.ObjectId);
+        }
+
+        /// <summary>
+        /// Get teams conversation members async test.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromRoster()
+        {
+            TeamsChannelAccount[] memberList = JsonConvert.DeserializeObject<TeamsChannelAccount[]>(File.ReadAllText(@"Jsons\SampleResponseGetTeamsConversationMembers.json"));
+
+            Assert.IsTrue(memberList.Count() == 2);
+            Assert.IsFalse(memberList.Any(member => string.IsNullOrEmpty(member.ObjectId)));
+            Assert.IsFalse(memberList.Any(member => string.IsNullOrEmpty(member.UserPrincipalName)));
+            Assert.IsFalse(memberList.Any(member => string.IsNullOrEmpty(member.Id)));
+            Assert.IsFalse(memberList.Any(member => string.IsNullOrEmpty(member.Email)));
+            Assert.IsFalse(memberList.Any(member => string.IsNullOrEmpty(member.Name)));
+        }
+    }
+}

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/TeamsChannelAccountTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/TeamsChannelAccountTests.cs
@@ -42,13 +42,15 @@ namespace Microsoft.Bot.Connector.Teams.Tests.Shared
     using Newtonsoft.Json;
     using System.Linq;
 
+    /// <summary>
+    /// TeamsChannelAccount tests
+    /// </summary>
     [TestClass]
     public class TeamsChannelAccountTests
     {
         /// <summary>
-        /// Get teams conversation members async test.
+        /// Parse out the AAD Object Id from a conversationUpdate event.
         /// </summary>
-        /// <returns>Task tracking operation.</returns>
         [TestMethod]
         public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromConversationUpdate()
         {
@@ -62,9 +64,8 @@ namespace Microsoft.Bot.Connector.Teams.Tests.Shared
         }
 
         /// <summary>
-        /// Get teams conversation members async test.
+        /// Parse out the AAD Object Id from a message event.
         /// </summary>
-        /// <returns>Task tracking operation.</returns>
         [TestMethod]
         public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromMessage()
         {
@@ -78,9 +79,8 @@ namespace Microsoft.Bot.Connector.Teams.Tests.Shared
         }
 
         /// <summary>
-        /// Get teams conversation members async test.
+        /// Parse out the AAD Object Id from a roster response.
         /// </summary>
-        /// <returns>Task tracking operation.</returns>
         [TestMethod]
         public void AsTeamsChannelAccount_ParsesAADIdCorrectlyFromRoster()
         {


### PR DESCRIPTION
The AAD Object Id comes from:
- the field 'objectId' if fetched from the roster API
- the field 'aadObjectId' if passed in through a message from bot framework.
