### PR TITLE
[C#] Support 1) Adaptive Card, and 2) bot-builder wrapped adaptive card actions

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/Microsoft.Bot.Connector.Teams.NetFramework.csproj
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/Microsoft.Bot.Connector.Teams.NetFramework.csproj
@@ -47,14 +47,14 @@
     <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/Microsoft.Bot.Connector.Teams.NetFramework.csproj
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/Microsoft.Bot.Connector.Teams.NetFramework.csproj
@@ -38,6 +38,9 @@
     <AssemblyOriginatorKeyFile>..\..\Build\272MSSharedLibSN2048.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdaptiveCards, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AdaptiveCards.1.0.3\lib\net452\AdaptiveCards.dll</HintPath>
+    </Reference>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
@@ -59,8 +62,8 @@
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Polly-Signed.5.3.1\lib\net45\Polly.dll</HintPath>

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/app.config
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/packages.config
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/packages.config
@@ -6,7 +6,7 @@
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.9.0.0" targetFramework="net46" />
   <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net46" />

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/packages.config
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.NetFramework/packages.config
@@ -1,14 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdaptiveCards" version="1.0.3" targetFramework="net46" />
   <package id="Autofac" version="3.5.2" targetFramework="net46" />
   <package id="AutoRest" version="0.17.3" targetFramework="net46" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net46" />
+  <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Polly-Signed" version="5.3.1" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
 </packages>

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/AdaptiveBotBuilderAction.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/AdaptiveBotBuilderAction.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+// Microsoft Teams: https://dev.office.com/microsoft-teams
+//
+// Bot Builder SDK GitHub:
+// https://github.com/Microsoft/BotBuilder
+//
+// Bot Builder SDK Extensions for Teams
+// https://github.com/OfficeDev/BotBuilder-MicrosoftTeams
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace Microsoft.Bot.Connector.Teams
+{
+    using Models;
+
+    /// <summary>
+    /// Adapter class to represent BotBuilder card action as adaptive card action (in type of Action.Submit).
+    /// </summary>
+    public class AdaptiveBotBuilderAction : AdaptiveCards.AdaptiveSubmitAction
+    {
+        /// <summary>
+        /// Constructor must wrap an existing CardAction from BotBuilder framework
+        /// </summary>
+        public AdaptiveBotBuilderAction(CardAction action)
+        {
+            this.RepresentAsBotBuilderAction(action);
+        }
+    }
+}

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/CardExtensions.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/CardExtensions.cs
@@ -33,6 +33,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Bot.Connector.Teams.Models
 {
     /// <summary>
@@ -83,6 +86,56 @@ namespace Microsoft.Bot.Connector.Teams.Models
                 ContentType = FileConsentCard.ContentType,
                 Name = card.Name,
             };
+        }
+
+        /// <summary>
+        /// Creates a new attachment from AdaptiveCard.
+        /// </summary>
+        /// <param name="card"> The instance of AdaptiveCard.</param>
+        /// <returns> The generated attachment.</returns>
+        public static Attachment ToAttachment(this AdaptiveCards.AdaptiveCard card)
+        {
+            return new Attachment
+            {
+                Content = card,
+                ContentType = AdaptiveCards.AdaptiveCard.ContentType
+            };
+        }
+
+        /// <summary>
+        /// Creates a new attachment from AdaptiveCardParseResult.
+        /// </summary>
+        /// <param name="cardParsedResult"> The instance of AdaptiveCardParseResult that represents results parsed from JSON string.</param>
+        /// <returns> The generated attachment.</returns>
+        public static Attachment ToAttachment(this AdaptiveCards.AdaptiveCardParseResult cardParsedResult)
+        {
+            return cardParsedResult.Card.ToAttachment();
+        }
+
+        /// <summary>
+        /// Wrap BotBuilder action into AdaptiveCard.
+        /// </summary>
+        /// <param name="action"> The instance of adaptive card.</param>
+        /// <param name="targetAction"> Target action to be adapted.</param>
+        public static void RepresentAsBotBuilderAction(this AdaptiveCards.AdaptiveSubmitAction action, CardAction targetAction)
+        {
+            var wrappedAction = new CardAction
+            {
+                Type = targetAction.Type,
+                Value = targetAction.Value,
+                Text = targetAction.Text,
+                DisplayText = targetAction.DisplayText
+            };
+
+            JsonSerializerSettings serializerSettings = new JsonSerializerSettings();
+            serializerSettings.NullValueHandling = NullValueHandling.Ignore;
+
+            string jsonStr = action.DataJson == null ? "{}" : action.DataJson;
+            JToken dataJson = JObject.Parse(jsonStr);
+            dataJson["msteams"] = JObject.FromObject(wrappedAction, JsonSerializer.Create(serializerSettings));
+
+            action.Title = targetAction.Title;
+            action.DataJson = dataJson.ToString();
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/Microsoft.Bot.Connector.Teams.Shared.projitems
+++ b/CSharp/Library/Microsoft.Bot.Connector.Teams.Shared/Microsoft.Bot.Connector.Teams.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ActivityExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AdaptiveBotBuilderAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdditionalProperties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CardExtensions.cs" />

--- a/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Microsoft.Bot.Connector.Teams.SampleBot.NetFramework.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Microsoft.Bot.Connector.Teams.SampleBot.NetFramework.csproj
@@ -45,6 +45,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdaptiveCards, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AdaptiveCards.1.0.3\lib\net452\AdaptiveCards.dll</HintPath>
+    </Reference>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
@@ -70,8 +73,8 @@
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Polly-Signed.5.3.1\lib\net45\Polly.dll</HintPath>

--- a/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Microsoft.Bot.Connector.Teams.SampleBot.NetFramework.csproj
+++ b/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Microsoft.Bot.Connector.Teams.SampleBot.NetFramework.csproj
@@ -54,14 +54,14 @@
     <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Web.config
+++ b/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/Web.config
@@ -9,10 +9,10 @@
     <add key="MicrosoftAppId" value="" />
     <add key="MicrosoftAppPassword" value="" />
     <add key="AllowedTenants" value="" />
-    <add key="SigninBaseUrl" value=""/>
-    <add key="SigninFbClientId" value=""/>
-    <add key="SigninFbClientSecret" value=""/>
-    <add key="SigninFbScope" value=""/>
+    <add key="SigninBaseUrl" value="" />
+    <add key="SigninFbClientId" value="" />
+    <add key="SigninFbClientSecret" value="" />
+    <add key="SigninFbScope" value="" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -28,13 +28,13 @@
       Having all default invalid characters for URL path except ':' as colon mark is used for user id which is part of path.
       Reference: https://msdn.microsoft.com/en-us/library/system.web.configuration.httpruntimesection.requestpathinvalidcharacters(v=vs.110).aspx
     -->
-    <httpRuntime targetFramework="4.6" requestPathInvalidCharacters="&lt;,&gt;,&amp;,*,%,\,?"/>
+    <httpRuntime targetFramework="4.6" requestPathInvalidCharacters="&lt;,&gt;,&amp;,*,%,\,?" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/packages.config
+++ b/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net461" />
+  <package id="Microsoft.Bot.Builder" version="3.9.0.0" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net461" />

--- a/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/packages.config
+++ b/CSharp/Samples/Microsoft.Bot.Connector.Teams.SampleBot/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdaptiveCards" version="1.0.3" targetFramework="net461" />
   <package id="Autofac" version="3.5.2" targetFramework="net461" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net461" />
@@ -8,10 +9,11 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="Polly-Signed" version="5.3.1" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net461" />
 </packages>

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/Microsoft.Bot.Connector.Teams.Tests.NetFramework.csproj
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/Microsoft.Bot.Connector.Teams.Tests.NetFramework.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdaptiveCards, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AdaptiveCards.1.0.3\lib\net452\AdaptiveCards.dll</HintPath>
+    </Reference>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
@@ -52,14 +55,15 @@
     <Reference Include="Microsoft.Bot.Connector, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Polly-Signed.5.3.1\lib\net45\Polly.dll</HintPath>

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/Microsoft.Bot.Connector.Teams.Tests.NetFramework.csproj
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/Microsoft.Bot.Connector.Teams.Tests.NetFramework.csproj
@@ -46,14 +46,14 @@
     <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.9.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.9.0.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/app.config
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/app.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/packages.config
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/packages.config
@@ -5,7 +5,7 @@
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net461" />
+  <package id="Microsoft.Bot.Builder" version="3.9.0.0" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net461" />

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/packages.config
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.NetFramework/packages.config
@@ -1,13 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdaptiveCards" version="1.0.3" targetFramework="net461" />
   <package id="Autofac" version="3.5.2" targetFramework="net461" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.Bot.Builder" version="3.5.9.0" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="Polly-Signed" version="5.3.1" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net461" />
 </packages>

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/CardTests.AdaptiveCard.cs
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/CardTests.AdaptiveCard.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+// Microsoft Teams: https://dev.office.com/microsoft-teams
+//
+// Bot Builder SDK GitHub:
+// https://github.com/Microsoft/BotBuilder
+//
+// Bot Builder SDK Extensions for Teams
+// https://github.com/OfficeDev/BotBuilder-MicrosoftTeams
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace Microsoft.Bot.Connector.Teams.Tests
+{
+    using System;
+    using System.IO;
+    using Microsoft.Bot.Connector.Teams.Models;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Adaptive card tests.
+    /// </summary>
+    public partial class CardTests
+    {
+        /// <summary>
+        /// Test ToAttachment() extension method where adaptive card is created from JSON.
+        /// </summary>
+        [TestMethod]
+        public void CardTests_AdaptiveCard_JsonToAttachment()
+        {
+            AdaptiveCards.AdaptiveCardParseResult card = AdaptiveCards.AdaptiveCard.FromJson(File.ReadAllText(@"Jsons\SampleAdaptiveCard.json"));
+            Attachment attachment = card.ToAttachment();
+
+            AdaptiveCards.AdaptiveCard expectedCard = new AdaptiveCards.AdaptiveCard();
+            expectedCard.Body.Add(new AdaptiveCards.AdaptiveTextBlock("some text on card"));
+
+            var action = new AdaptiveCards.AdaptiveOpenUrlAction();
+            action.Url = new Uri("https://microsoft.com");
+            expectedCard.Actions.Add(action);
+
+            Assert.IsNotNull(attachment);
+            Assert.IsNotNull(attachment.Content);
+            Assert.IsNotNull(attachment.ContentType);
+            Assert.AreEqual(attachment.ContentType, AdaptiveCards.AdaptiveCard.ContentType);
+            Assert.IsTrue(JObject.DeepEquals(JObject.FromObject(expectedCard), JObject.FromObject(attachment.Content)));
+        }
+
+        /// <summary>
+        /// Test ToAttachment() extension method where card is created from AdaptiveCard object.
+        /// </summary>
+        [TestMethod]
+        public void CardTests_AdaptiveCard_CardToAttachment()
+        {
+            AdaptiveCards.AdaptiveCard card = new AdaptiveCards.AdaptiveCard();
+            card.Body.Add(new AdaptiveCards.AdaptiveTextBlock("some text on card"));
+
+            var action = new AdaptiveCards.AdaptiveOpenUrlAction();
+            action.Url = new Uri("https://microsoft.com");
+            card.Actions.Add(action);
+
+            Attachment attachment = card.ToAttachment();
+
+            Assert.IsNotNull(attachment);
+            Assert.IsNotNull(attachment.Content);
+            Assert.IsNotNull(attachment.ContentType);
+            Assert.AreEqual(attachment.ContentType, AdaptiveCards.AdaptiveCard.ContentType);
+            Assert.IsTrue(JObject.DeepEquals(JObject.FromObject(card), JObject.FromObject(attachment.Content)));
+        }
+
+        /// <summary>
+        /// Test for adaptive card wrapping BotBuilder actions 
+        /// where action is wrapped by AdaptiveSubmitAction extension method RepresentAsBotBuilderAction() 
+        /// that can represent itself as a BotBuilder action.
+        /// </summary>
+        [TestMethod]
+        public void CardTests_AdaptiveCard_BotBuilderAction_RepresentAsBotBuilderAction()
+        {
+            var wrapAction = new CardAction
+            {
+                Type = "imback",
+                Value = "Text",
+                Title = "button title"
+            };
+
+            var action = new AdaptiveCards.AdaptiveSubmitAction();
+            action.DataJson = @"{""key"": ""value""}";
+            action.RepresentAsBotBuilderAction(wrapAction);
+
+            var expectedAction = JsonConvert.DeserializeObject(@"{
+                ""type"": ""Action.Submit"",
+                ""title"": ""button title"",
+                ""data"": {
+                    ""key"": ""value"",
+                    ""msteams"": {
+                        ""type"": ""imback"",
+                        ""value"": ""Text""
+                    }
+                }
+            }");
+
+            Assert.IsTrue(JObject.DeepEquals(JObject.FromObject(expectedAction), JObject.FromObject(action)));
+
+            var card = new AdaptiveCards.AdaptiveCard();
+            card.Body.Add(new AdaptiveCards.AdaptiveTextBlock());
+            card.Actions.Add(action);
+
+            Attachment attachment = card.ToAttachment();
+            this.TestCard(attachment);
+        }
+
+        /// <summary>
+        /// Test for adaptive card wrapping BotBuilder actions
+        /// where action is wrapped by adapter class AdaptiveBotBuilderAction
+        /// that can seamlessly seal BotBuilder card action into an adaptive card action.
+        /// </summary>
+        [TestMethod]
+        public void CardTests_AdaptiveCard_BotBuilderAction_AdaptiveBotBuilderAction()
+        {
+            var wrapAction = new CardAction
+            {
+                Type = "messageBack",
+                Value = "some value to bots",
+                Title = "button title",
+                Text = "text posting back to bots",
+                DisplayText = "display text injected in chat stream"
+            };
+
+            var action = new AdaptiveBotBuilderAction(wrapAction);
+
+            var expectedAction = JsonConvert.DeserializeObject(@"{
+                ""type"": ""Action.Submit"",
+                ""title"": ""button title"",
+                ""data"": {
+                    ""msteams"": {
+                        ""type"": ""messageBack"",
+                        ""value"": ""some value to bots"",
+                        ""text"": ""text posting back to bots"",
+                        ""displayText"": ""display text injected in chat stream"",
+                    }
+                }
+            }");
+
+            Assert.IsTrue(JObject.DeepEquals(JObject.FromObject(expectedAction), JObject.FromObject(action)));
+
+            var card = new AdaptiveCards.AdaptiveCard();
+            card.Body.Add(new AdaptiveCards.AdaptiveTextBlock());
+            card.Actions.Add(action);
+
+            Attachment attachment = card.ToAttachment();
+            this.TestCard(attachment);
+        }
+    }
+}

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleAdaptiveCard.json
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Jsons/SampleAdaptiveCard.json
@@ -1,0 +1,16 @@
+﻿{
+  "type": "AdaptiveCard",
+  "version": "1.0",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "some text on card"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.OpenUrl",
+      "url":  "https://microsoft.com"
+    }
+  ]
+}

--- a/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Microsoft.Bot.Connector.Teams.Tests.Shared.projitems
+++ b/CSharp/Tests/Microsoft.Bot.Connector.Teams.Tests.Shared/Microsoft.Bot.Connector.Teams.Tests.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.Bot.Connector.Teams.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CardTests.AdaptiveCard.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CardTests.FileCards.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComposeExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MentionTests.cs" />
@@ -67,6 +68,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleActivitySigninAuthStateVerification.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleAdaptiveCard.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)Jsons\SampleFileConsentCardResponseInvoke.json">


### PR DESCRIPTION
[C#] Support 1) Adaptive Card, and 2) bot-builder wrapped adaptive card actions

1. Adaptive Card
  - Add Adaptive Card SDK dependency.
  - Add extension method to convert adaptive card JSON to attachment object
  - Add extension method to convert AdaptiveCard object to attachment object

2. Bot-builder wrapped adaptive card actions
  - Support bot-builder actions on adaptive cards (in type of Action.Submit)
  - Provide an Action.Submit extension method to represent itself as a BotBuilder card action
  - Provide an adapter class AdaptiveBotBuilderAction to seamlessly seal an existing BotBuilder object as an adaptive card action.

3. Update BotBuilder SDK version to 3.9.0 to support interface for "messageBack" type of CardAction (having "Text" and "DisplayText" added) that are necessary in this PR.
